### PR TITLE
Compare with name instead of order number

### DIFF
--- a/app.js
+++ b/app.js
@@ -162,7 +162,7 @@
       if (orderId) {
         // Check if custom field order is in the array
         var ticketOrder = _.find(this.orders, function(order){
-          return (order.order_number == orderId);
+          return (order.name == "#" + orderId);
         });
 
         if (ticketOrder) {


### PR DESCRIPTION
Compare with name which is what we display in the sidebar instead of order_number for new POS type orders which have different order number and name.

Fixes: https://support.zendesk.com/agent/tickets/1208812

/cc @jwswj @joseconsador @iandjx @mmolina @danielbreves @maximeprades @pelletier 

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-287

### Risks
* Medium. Orders might not appear properly