### PR TITLE
[MI-287] Show order number instead of order name

### DIFF
--- a/templates/customer.hdbs
+++ b/templates/customer.hdbs
@@ -13,7 +13,7 @@
     <tbody>
       {{#recentOrders}}
         <tr class="_tooltip" data-placement="top">
-          <td><a href="{{uri}}" target="_blank">{{name}}</a></td>
+          <td><a href="{{uri}}" target="_blank">{{order_number}}</a></td>
           <td><span class="badge o-{{fulfillment_status}}">{{fulfillment_status}}</span></td>
         </tr>
       {{/recentOrders}}


### PR DESCRIPTION
An alternative to https://github.com/zendesk/shopify_app/pull/19 where we just display the order number.

/cc @jwswj @joseconsador @iandjx @pdeuter @mmolina

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-287

### Risks
* Medium. Orders might not appear properly