### PR TITLE
[MI-319] Allow name the id passed in the custom field when finding an order

### DIFF
--- a/app.js
+++ b/app.js
@@ -161,9 +161,7 @@
     showTicketOrder: function(orderId) {
       if (orderId) {
         // Check if custom field order is in the array
-        var ticketOrder = _.find(this.orders, function(order){
-          return (order.order_number == orderId);
-        });
+        var ticketOrder = this.findOrder(orderId);
 
         if (ticketOrder) {
           this.updateTemplate('order', ticketOrder);
@@ -171,6 +169,12 @@
           this.showError(this.I18n.t('global.error.orderNotFound'), " ", 'order');
         }
       }
+    },
+
+    findOrder: function(orderId) {
+      return _.find(this.orders, function(order){
+        return ((order.order_number == orderId) || (order.name == orderId) || (order.name == '#' + orderId));
+      });
     },
 
     fmtOrder: function(order) {

--- a/templates/customer.hdbs
+++ b/templates/customer.hdbs
@@ -13,7 +13,7 @@
     <tbody>
       {{#recentOrders}}
         <tr class="_tooltip" data-placement="top">
-          <td><a href="{{uri}}" target="_blank">{{order_number}}</a></td>
+          <td><a href="{{uri}}" target="_blank">{{name}}</a></td>
           <td><span class="badge o-{{fulfillment_status}}">{{fulfillment_status}}</span></td>
         </tr>
       {{/recentOrders}}


### PR DESCRIPTION
Allowed values are now order number, order name, '#' + order name.
This will make it easier to use for the customer and at the same time it is backward compatible.

Also reverted what we display to order name

/cc @jwswj @joseconsador @pdeuter @danielbreves @maximeprades @pelletier 

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-319

### Risks
* Medium. The order might not display correctly.