### PR TITLE
[MI-792] Limit "Order Notes" and "Customer Notes" to 165 characters

### DIFF
--- a/src/javascripts/shopify_app.js
+++ b/src/javascripts/shopify_app.js
@@ -5,6 +5,8 @@ var gravatar = require('gravatar');
 var ShopifyApp = {
   orderLimit: 3,
 
+  noteCharacterLimit: 165,
+
   orderFieldsMap: {
     "items_purchased": "line_items",
     "item_quantity": "quantity",
@@ -33,7 +35,10 @@ var ShopifyApp = {
     'getProfile' : function(email) {
       var request = this.getRequest(this.resources.PROFILE_URI);
 
-      request.data = {query: 'email:' + email};
+      request.data = {
+        query: 'email:' + email,
+        fields: 'id,note,email,first_name,last_name'
+      };
 
       return request;
     },
@@ -113,7 +118,7 @@ var ShopifyApp = {
     if (this.setting('customer_notes') && (this.customer.note === "" || this.customer.note === null)) {
       this.customer.note = this.I18n.t('customer.no_notes');
     } else {
-      this.customer.note = null;
+      this.customer.note = this.truncateTextToLimit(this.customer.note);
     }
 
     this.customer.uri = this.storeUrl + this.resources.CUSTOMER_URI + this.customer.id;
@@ -216,6 +221,8 @@ var ShopifyApp = {
 
     if (order.note === "" || order.note === null) {
       newOrder.note = this.I18n.t('customer.no_notes');
+    } else {
+      newOrder.note = this.truncateTextToLimit(order.note);
     }
 
     if (order.created_at) {
@@ -223,6 +230,13 @@ var ShopifyApp = {
     }
 
     return newOrder;
+  },
+  
+  truncateTextToLimit: function (text) {
+    if (text.length > this.noteCharacterLimit) {
+      return text.substr(0, this.noteCharacterLimit) + '...';
+    }
+    return text;
   }
 }
 

--- a/src/stylesheets/ticket_sidebar.scss
+++ b/src/stylesheets/ticket_sidebar.scss
@@ -2,4 +2,8 @@ section[data-main] {
   h3 {
     margin-top: 5px;
   }
+
+  .order-note {
+    white-space: normal;
+  }
 }

--- a/src/templates/customer.hdbs
+++ b/src/templates/customer.hdbs
@@ -9,7 +9,7 @@
 {{#if customer.note}}
 <div class="u-mb-sm u-zeta">
   {{t "customer.notes"}}
-  <div class="u-light">{{customer.note}}</div>
+  <div class="u-light"><p>{{customer.note}}</p></div>
 </div>
 {{/if}}
 

--- a/src/templates/partials/order.hdbs
+++ b/src/templates/partials/order.hdbs
@@ -54,7 +54,7 @@
       {{#if note}}
       <div class="u-mv-sm">
         <div class="u-semibold o-label">{{t "app.parameters.order_notes.label.value"}}</div>
-        <div>{{note}}</div>
+        <div class="order-note">{{note}}</div>
       </div>
       {{/if}}
     <!-- /#panel-body -->


### PR DESCRIPTION
/cc @zendesk/mintegrations @miketineo @mmolina

### Description

Limit the amount of characters we must display to 165 for the notes of the customer and the orders.

![mio_s_amazing_zendesk_-_agent](https://cloud.githubusercontent.com/assets/1471573/18379568/d4183c78-76a5-11e6-8d24-d70ef092bdaf.png)


### References
* JIRA: https://zendesk.atlassian.net/browse/MI-792

### Risks
* low. Customer and order notes might not show up