### PR TITLE
[MI-779] Remove unnecessary horizontal scroll

### DIFF
--- a/src/templates/order/list.hdbs
+++ b/src/templates/order/list.hdbs
@@ -2,7 +2,7 @@
   <div class="l-grid__item u-1/2">
     <span>{{t "orders.recent_orders"}}</span>
   </div>
-  <div class="l-grid__item u-1/2 u-ta-right u-pr-sm">
+  <div class="l-grid__item u-1/2 u-ta-right u-pr-sm u-m-xs-">
     <a href="{{ordersUri}}" target="_blank">{{t "orders.view_all"}}</a>
   </div>
 </div>


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Remove width overflow due to space between inline-block divs by applying a small negative margin.

![screen shot 2016-09-27 at 6 09 17 pm](https://cloud.githubusercontent.com/assets/8102514/18869131/8adcfd1e-84dd-11e6-82e0-9afdd981249c.png)


### References
* JIRA: https://zendesk.atlassian.net/browse/MI-779
* CSS Reference: https://css-tricks.com/fighting-the-space-between-inline-block-elements/

### Risks
* [low] Page may not fit nicely within iframe.
