### PR TITLE
[MI-1087] Clicking on order row will expand order details

### DIFF
--- a/lib/javascripts/base_app.js
+++ b/lib/javascripts/base_app.js
@@ -186,7 +186,7 @@ BaseApp.prototype = {
   },
 
   isZatEnabled: function() {
-    return (this.id() === 0);
+    return (parseInt(this.id()) === 0);
   }
 
 }

--- a/src/javascripts/shopify_app.js
+++ b/src/javascripts/shopify_app.js
@@ -338,7 +338,7 @@ var ShopifyApp = {
   },
 
   isZatEnabled: function() {
-    return (this.id() === 0);
+    return (parseInt(this.id()) === 0);
   }
 }
 

--- a/src/templates/partials/order.hdbs
+++ b/src/templates/partials/order.hdbs
@@ -1,9 +1,9 @@
 <div class="panel panel-default u-pv-sm u-pv">
-  <div class="panel-heading" role="tab" id="heading-{{id}}">
+  <div class="panel-heading accordion-toggle" role="tab" id="heading-{{id}}" data-toggle="collapse" data-parent="#accordion" href="#order-{{id}}">
     <ul class="flat-dotted-list">
       <li>
         <h4 class="panel-title">
-          <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#order-{{id}}" aria-expanded="false" aria-controls="order-{{id}}">
+          <a class="collapsed" role="button" aria-expanded="false" aria-controls="order-{{id}}">
             {{name}}
           </a>
         </h4>


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

* fix isZatEnabled wrongfully returns false if app id is zero of type string
* clicking on order row will expand order details instead of clicking on the order id only

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1087

### Risks
* none