### PR TITLE
[MI-1087] Collapse other expanded orders

### DIFF
--- a/src/javascripts/shopify_app.js
+++ b/src/javascripts/shopify_app.js
@@ -1,6 +1,4 @@
 import BaseApp from 'base_app';
-import $ from 'jquery';
-
 import TweenMax from 'gsap';
 
 var gravatar = require('gravatar');
@@ -84,6 +82,7 @@ var ShopifyApp = {
     'getOrders.fail' : 'handleOrdersFail',
     'getOrder.done' : 'handleOrder',
     'getOrder.fail' : 'handleOrdersFail',
+    'show.bs.collapse .panel-group': 'collapseOpenPanels',
     'shown.bs.collapse .panel-group': 'resizeApp',
     'hidden.bs.collapse .panel-group': 'resizeApp',
     'click #orders-toggle': 'toggleOrders',
@@ -209,7 +208,7 @@ var ShopifyApp = {
 
     newOrder.uri = this.storeUrl + this.resources.ORDER_PATH + order.id;
 
-    if (this.setting('items_purchased')) {    
+    if (this.setting('items_purchased')) {
       newOrder.items_purchased = _.map(order.line_items, function(line_item) {
         var item = [];
         item.title = line_item.title;
@@ -253,7 +252,7 @@ var ShopifyApp = {
 
     return newOrder;
   },
-  
+
   truncateTextToLimit: function (text) {
     if (text.length > this.noteCharacterLimit) {
       return text.substr(0, this.noteCharacterLimit) + '...';
@@ -263,8 +262,8 @@ var ShopifyApp = {
 
   loadSprites: function() {
     var svg = require('zd-svg-icons/dist/index.svg');
-    var $svg = $('<object id="mySVG" type="image/svg+xml"/>').css('display', 'none').append(svg);
-    $('body').prepend($svg);
+    var $svg = this.$('<object id="mySVG" type="image/svg+xml"/>').css('display', 'none').append(svg);
+    this.$('body').prepend($svg);
   },
 
   toggleOrders: function() {
@@ -281,11 +280,14 @@ var ShopifyApp = {
     }
 
     TweenMax.to("#orders-toggle", .5, {rotation: rotation});
-    $('section[data-orders] .panel-collapse').collapse(show);
+    this.$('section[data-orders] .panel-collapse')
+          .addClass('grouped-action')
+          .collapse(show)
+          .removeClass('grouped-action');
   },
 
   resizeApp: function() {
-    let newHeight = $('body').height();
+    let newHeight = this.$('body').height();
     this.zafClient.invoke('resize', { height: newHeight, width: '100%' });
   },
 
@@ -344,6 +346,12 @@ var ShopifyApp = {
 
   stopPropagation: function(event) {
       event.stopPropagation();
+  },
+
+  collapseOpenPanels: function(x) {
+      this.$('section[data-orders] .panel-group .in')
+          .not('.grouped-action')
+          .collapse('hide');
   }
 }
 

--- a/src/templates/order/list.hdbs
+++ b/src/templates/order/list.hdbs
@@ -9,8 +9,8 @@
 
 <hr/>
 <!---- Order list ---->
+<div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">    
 {{#each orders}}
-<div class="panel-group" id="accordion-{{id}}" role="tablist" aria-multiselectable="true">
   {{> order}}
-</div>
 {{/each}}
+</div>


### PR DESCRIPTION
/cc @zendesk/mintegrations @kcasas 

### Description

Implement an accordion-like behavior to collapse other currently expanded orders when an order is expanded. One open panel at a time but allow collapsing/expanding all panels together via the `#orders-toggle` button. 

![accordion-like](https://cloud.githubusercontent.com/assets/8102514/21385639/401d624a-c7aa-11e6-8d51-4969a5ec7546.gif)

This is a missing acceptance criteria from: https://github.com/zendesk/shopify_app/pull/45

Note: As a side note, this behavior does not actually use `bootstrap-accordion` but instead simply relies on the `bootstrap-collapse` functionality similar to the current implementation. As such, the accordion classes such as `panel` etc. in the [orders markup](https://github.com/zendesk/shopify_app/blob/9f9692cbc1a5062ae87ebb9c5f30f1d1c3ddaa15/src/templates/partials/order.hdbs#L1) can be a bit misleading since they aren't actually used, since these are for bootstrap 3 and zaf currently loads bootstrap 2 by default, we can probably remove this classes in the future to avoid confusion.

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1087

### Risks
* [medium] Orders may not be toggle-able.