### PR TITLE
[MI-1338] Only show the shipping and billing address if there is an address

### DIFF
--- a/src/templates/partials/order.hdbs
+++ b/src/templates/partials/order.hdbs
@@ -37,14 +37,14 @@
           <div>{{title}}</div>
         </div>
       {{/if}}
-      {{#if shipping_address}}
+      {{#if shipping_address.address1}}
         <div class="u-mv-sm">
           <div class="u-semibold o-label">{{t "app.parameters.shipping_address.label.value"}}</div>
           <div>{{shipping_address.address1}} {{shipping_address.address2}}</div>
           <div>{{shipping_address.city}}, {{shipping_address.province_code}} {{shipping_address.zip}}</div>
         </div>
       {{/if}}
-      {{#if billing_address}}
+      {{#if billing_address.address1}}
         <div class="u-mv-sm">
           <div class="u-semibold o-label">{{t "app.parameters.billing_address.label.value"}}</div>
           <div>{{billing_address.address1}} {{billing_address.address2}}</div>


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Only show the shipping and billing address if there is an address and it is not null

Before:
![mio_s_amazing_zendesk_-_agent](https://cloud.githubusercontent.com/assets/1471573/23294559/f5fec2b4-faa6-11e6-97c6-ca5b3277e06e.png)

After:
![mio_s_amazing_zendesk_-_agent](https://cloud.githubusercontent.com/assets/1471573/23294561/fbeede52-faa6-11e6-9b8b-6b211bff07d5.png)


### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1338

### Risks
* medium. Shipping and billing address might not display correctly