### PR TITLE
Fix bug where customer cannot be rendered when `customer_note setting…

### DIFF
--- a/src/javascripts/shopify_app.js
+++ b/src/javascripts/shopify_app.js
@@ -126,7 +126,9 @@ var ShopifyApp = {
 
     this.customer = data.customers[0];
 
-    if (this.setting('customer_notes') && (this.customer.note === "" || this.customer.note === null)) {
+    if (!this.setting('customer_notes')) {
+      this.customer.note = false;
+    } else if (this.customer.note === "" || this.customer.note === null) {
       this.customer.note = this.I18n.t('customer.no_notes');
     } else {
       this.customer.note = this.truncateTextToLimit(this.customer.note);


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Fix bug where customer cannot be rendered when `customer_note setting` is false and the `customer note` is null

It was being stuck at 
<img width="366" alt="z3nmio_-_agent" src="https://cloud.githubusercontent.com/assets/1471573/23352517/94f78196-fd02-11e6-8685-e6b3397e9acb.png">

After, it can now advance to 
<img width="367" alt="z3nmio_-_agent_and_postman" src="https://cloud.githubusercontent.com/assets/1471573/23352527/a365c760-fd02-11e6-9ee1-9a0a5b5b43c9.png">


### References
* JIRA: 

### Risks
* Medium. Customer notes might not display correctly.