### PR TITLE
[MI-1370] Add filters to view all orders link

### DIFF
--- a/src/javascripts/shopify_app.js
+++ b/src/javascripts/shopify_app.js
@@ -198,7 +198,7 @@ var ShopifyApp = {
     this.$('section[data-orders]').html(
       this.renderTemplate('order/list', {
         orders: this.orders.slice(0,3),
-        ordersUri: this.storeUrl + this.resources.ORDER_PATH
+        ordersUri: this.storeUrl + this.resources.ORDER_PATH + '?query=&customer_id=' + this.customer.id
       })
     );
 


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Add filters to the `view all orders` link
![z3nmio_-_agent](https://cloud.githubusercontent.com/assets/1471573/23396022/84e54d4a-fdcc-11e6-9991-783bb0e74558.png)


Previously it would show all orders:
![fullscreen_28_02_2017__3_39_pm](https://cloud.githubusercontent.com/assets/1471573/23395950/2b01ec02-fdcc-11e6-871a-056abf3a4a7b.png)

Now it shows orders of the customer in question only
![fullscreen_28_02_2017__3_38_pm](https://cloud.githubusercontent.com/assets/1471573/23395916/0f45caba-fdcc-11e6-9bb0-aa094e30c96e.png)


### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1370

### Risks
* low. The view all orders link might not work