### PR TITLE
[MI 1368] Correctly hide order notes

### DIFF
--- a/src/javascripts/shopify_app.js
+++ b/src/javascripts/shopify_app.js
@@ -237,10 +237,12 @@ var ShopifyApp = {
       newOrder.fulfillment_status = true;
     }
 
-    if (order.note) {
-      newOrder.note = this.truncateTextToLimit(order.note);
-    } else {
-      newOrder.note = this.I18n.t('customer.no_notes');
+    if (this.setting.order_notes) {
+      if (order.note) {
+        newOrder.note = this.truncateTextToLimit(order.note);
+      } else {
+        newOrder.note = this.I18n.t('customer.no_notes');
+      }
     }
 
     if (order.created_at) {


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description
Fixed a bug that shows order notes even though on settings `order_notes: false`

**Before:**
![before](https://cloud.githubusercontent.com/assets/1477171/23452093/dd3af3ec-fe9d-11e6-80ab-d15f7d9d01dd.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/1477171/23452094/dd3c86ee-fe9d-11e6-8dd7-57eadcc32cbd.png)

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1368

### Risks
* [low] order notes might not be in order even if it exists