### PR TITLE
[MI-1458] set target to blank

### DIFF
--- a/src/templates/partials/order.hdbs
+++ b/src/templates/partials/order.hdbs
@@ -55,7 +55,7 @@
         <div class="u-mv-sm">
             <div class="u-semibold o-label">{{t "app.parameters.tracking_numbers.label.value"}}</div>
             {{#each tracking_numbers}}
-              <div> <a href="{{tracking_url}}">{{tracking_number}}</a></div>
+              <div> <a href="{{tracking_url}}" target="_blank">{{tracking_number}}</a></div>
             {{/each}}
         </div>
       {{/if}}


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Opens any tracking page on a new tab to prevent iframe navigation issues.

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1458

### Risks
* [medium] Could cause a security issue when the link for the tracking URL is compromised.