### PR TITLE
[MI-1464] make translations load from new format

### DIFF
--- a/lib/javascripts/i18n.js
+++ b/lib/javascripts/i18n.js
@@ -1,4 +1,6 @@
+import Handlebars from 'handlebars';
 import manifest from 'app_manifest';
+
 const defaultLocale = manifest.defaultLocale || 'en';
 
 let translations;
@@ -11,7 +13,7 @@ function tryRequire(locale) {
   }
 }
 
-module.exports = Object.freeze({
+const I18n = Object.freeze({
   t: function(key, context) {
     if (!translations) {
       throw new Error('Translations must be initialized with I18n.loadTranslations before calling `t`.');
@@ -20,7 +22,7 @@ module.exports = Object.freeze({
     if (keyType !== 'string') {
       throw new Error(`Translation key must be a string, got: ${keyType}`);
     }
-    var template = _.at(translations, key)[0];
+    var template = translations[key] || translations[`${key}.value`];
     if (!template) {
       throw new Error(`Missing translation: ${key}`);
     }
@@ -29,7 +31,7 @@ module.exports = Object.freeze({
         throw new Error(`Invalid translation for key: ${key}`);
       }
       template = Handlebars.compile(template);
-      _.set(translations, key, template);
+      translations[key] = template;
     }
     var html = template(context);
     return html;
@@ -41,3 +43,14 @@ module.exports = Object.freeze({
       {};
   }
 });
+
+Handlebars.registerHelper('t', function(key, context) {
+  try {
+    return I18n.t(key, context.hash);
+  } catch(e) {
+    console.error(e);
+    return e.message;
+  }
+});
+
+module.exports = I18n;


### PR DESCRIPTION
/cc @zendesk/mintegrations

### Description

Make translations load from `title` and `value` format as well. Somehow some installations are loaded with different formats for translations.

### References
* JIRA: https://zendesk.atlassian.net/browse/MI-1464
* app_scaffold PR: https://github.com/zendesk/app_scaffold/pull/59

### Risks
* [medium] All translations could not be found.